### PR TITLE
Improve .gitignore coverage and add test cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,27 @@
+# Dependencies
 node_modules/
+
+# OS files
 .DS_Store
+Thumbs.db
+
+# Editor / IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Build artifacts
 assets/
+
+# Test artifacts
+/tmp/test-brain/
+
+# Runtime data
+*.log
+npm-debug.log*
+
+# Environment
+.env
+.env.local

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Git-native shared AI memory for teams — auto-generates CLAUDE.md, .cursorrules, and AGENTS.md",
   "main": "scripts/store.js",
   "scripts": {
+    "pretest": "rm -rf /tmp/test-brain",
     "test": "node scripts/store.js init /tmp/test-brain && node scripts/store.js add-entry /tmp/test-brain lesson 'Test lesson' 'Test content' tester test && node scripts/search.js search /tmp/test-brain test && echo 'All checks passed'",
+    "posttest": "rm -rf /tmp/test-brain",
     "init": "node scripts/store.js init",
     "generate": "node scripts/generator.js generate",
     "stats": "node scripts/stats.js"


### PR DESCRIPTION
## Summary
- Expanded `.gitignore` with missing entries for editor/IDE files (`.vscode/`, `.idea/`, swap files), OS files (`Thumbs.db`), logs (`*.log`, `npm-debug.log*`), environment files (`.env`, `.env.local`), and test artifacts (`/tmp/test-brain/`)
- Added `pretest` and `posttest` npm scripts to clean up the `/tmp/test-brain` temp directory before and after test runs, preventing stale state from affecting results

## Test plan
- [x] Verified `npm test` passes with the new pre/post scripts
- [x] Verified `/tmp/test-brain` is removed after test completion
- [ ] Confirm no previously tracked files are now erroneously ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)