### PR TITLE
Add issue templates and community discussion link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug Report
+about: Report a bug with Team Brain
+title: '[Bug] '
+labels: bug
+assignees: ''
+---
+
+## Describe the Bug
+A clear description of what the bug is.
+
+## Steps to Reproduce
+1. Install team-brain
+2. Run '...'
+3. See error
+
+## Expected Behavior
+What you expected to happen.
+
+## Environment
+- OS:
+- Node.js version:
+- Git version:
+- Team Brain version:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussions
+    url: https://github.com/Manavarya09/team-brain/discussions
+    about: Ask questions and share ideas

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature Request
+about: Suggest a feature for Team Brain
+title: '[Feature] '
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+What problem does this feature solve?
+
+## Proposed Solution
+Describe what you'd like.
+
+## Use Case
+How would your team use this feature?


### PR DESCRIPTION
## Summary
- Bug report template with environment details
- Feature request template focused on team use cases
- Config to enable blank issues and link to Discussions

## Why
Standardizes how the community reports bugs and requests features, reducing back-and-forth on incomplete reports.