### PR TITLE
feat: entry expiration and staleness detection

### DIFF
--- a/scripts/generator.js
+++ b/scripts/generator.js
@@ -19,7 +19,11 @@ function generateBrain(projectRoot) {
   lines.push('');
 
   for (const type of priorityOrder) {
-    const entries = store.listEntries(projectRoot, type).filter(e => e.meta.status !== 'deprecated');
+    const typeEntries = store.listEntries(projectRoot, type).filter(e => e.meta.status !== 'deprecated');
+    // Sort expired entries to the end
+    const active = typeEntries.filter(e => !store.isExpired(e.meta));
+    const expired = typeEntries.filter(e => store.isExpired(e.meta));
+    const entries = [...active, ...expired];
     if (entries.length === 0) continue;
 
     // Check if we have room
@@ -38,16 +42,17 @@ function generateBrain(projectRoot) {
       const title = entry.meta.title || entry.filename;
       const author = config.include_authors ? ` (${entry.meta.author || 'unknown'})` : '';
       const date = config.include_dates ? ` [${entry.meta.date || ''}]` : '';
+      const stale = store.isExpired(entry.meta) ? ' ⚠ STALE' : '';
 
       if (type === 'conventions') {
         // Conventions get the full first paragraph
         const firstPara = entry.body.trim().split('\n\n')[0].replace(/^#+\s.*\n?/, '').trim();
-        lines.push(`- **${title}**: ${firstPara}`);
+        lines.push(`- **${title}**: ${firstPara}${stale}`);
       } else if (type === 'decisions') {
         const status = entry.meta.status || 'accepted';
-        lines.push(`- **${title}** (${status})${date}${author}`);
+        lines.push(`- **${title}** (${status})${date}${author}${stale}`);
       } else {
-        lines.push(`- ${title}${date}${author}`);
+        lines.push(`- ${title}${date}${author}${stale}`);
       }
     }
 

--- a/scripts/store.js
+++ b/scripts/store.js
@@ -63,6 +63,19 @@ function today() {
   return new Date().toISOString().slice(0, 10);
 }
 
+function isExpired(meta) {
+  const now = new Date(today());
+  if (meta.expires) {
+    return new Date(meta.expires) <= now;
+  }
+  if (meta.ttl_days && meta.date) {
+    const created = new Date(meta.date);
+    created.setDate(created.getDate() + parseInt(meta.ttl_days, 10));
+    return created <= now;
+  }
+  return false;
+}
+
 // --- Project Root ---
 
 function findProjectRoot(startDir) {
@@ -238,7 +251,7 @@ function saveConfig(projectRoot, config) {
 }
 
 module.exports = {
-  slugify, parseFrontmatter, buildFrontmatter, getAuthor, today,
+  slugify, parseFrontmatter, buildFrontmatter, getAuthor, today, isExpired,
   findProjectRoot, brainDir, init,
   addEntry, listEntries, readEntry, getNextDecisionNumber,
   getContributors, addContributor, loadConfig, saveConfig,


### PR DESCRIPTION
## Summary
- Support optional `expires` (date) and `ttl_days` (integer) fields in entry frontmatter
- Expired entries are sorted to the end of BRAIN.md sections and tagged with ⚠ STALE
- New `isExpired()` helper exported from store.js for use by other modules (stats, search, etc.)

## Example usage
```yaml
---
title: Workaround for API rate limit bug
type: lesson
date: 2025-01-15
ttl_days: 90
---
```

Or with an explicit date:
```yaml
---
title: Use legacy auth endpoint
type: lesson  
expires: 2025-06-01
---
```

## Test plan
- [ ] Add an entry with `ttl_days: 1` and `date` set to yesterday, verify it shows as STALE in BRAIN.md
- [ ] Add an entry with `expires` in the past, verify staleness
- [ ] Entries without TTL/expires remain unaffected
- [ ] Expired entries sort to the bottom of their type section

🤖 Generated with [Claude Code](https://claude.com/claude-code)