### PR TITLE
chore: add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,bat,ps1} text eol=crlf
+*.{png,jpg,jpeg,gif,ico,svg,woff,woff2,ttf,eot} binary


### PR DESCRIPTION
Normalises line endings to LF and marks common binary file types.